### PR TITLE
fix: remove github pages deploy from pipeline as we use branch instead [skip ci]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,4 +28,3 @@ jobs:
         run: |
           yarn build
           yarn run semantic-release
-          yarn gh-pages

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tooltip-example",
-  "homepage": "https://wwayne.github.io/react-tooltip/",
+  "homepage": "https://reacttooltip.github.io/react-tooltip/",
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "prop-types": "^15.8.1",
-    "uuid": "9.0.0"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11912,10 +11912,10 @@ util@~0.12.0:
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
 
-uuid@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+uuid@8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
* fix: remove github pages deploy from the pipeline as we use a branch instead
* rollback: revert the upgrade in `uuid` package as it was breaking the examples page build (as we use old packages)

No new release required for that as the plugin is correctly working with the uuid upgraded, we just need upgrade our example folder packages before restore the uuid upgraded.