### PR TITLE
Use `ReactNode` for wrapper children type instead of `ReactElement`

### DIFF
--- a/src/components/TooltipProvider/TooltipProviderTypes.d.ts
+++ b/src/components/TooltipProvider/TooltipProviderTypes.d.ts
@@ -1,4 +1,4 @@
-import type { MutableRefObject, ReactElement, RefObject } from 'react'
+import type { MutableRefObject, ReactNode, RefObject } from 'react'
 import type { ITooltipController } from 'components/TooltipController/TooltipControllerTypes'
 
 export type AnchorRef = RefObject<HTMLElement>
@@ -19,7 +19,7 @@ export type TooltipContextDataWrapper = TooltipContextData & {
 export interface ITooltipWrapper {
   tooltipId?: string
   forwardRef?: MutableRefObject<HTMLElement | null>
-  children: ReactElement
+  children: ReactNode
 
   place?: ITooltipController['place']
   content?: ITooltipController['content']

--- a/src/components/TooltipProvider/TooltipProviderTypes.d.ts
+++ b/src/components/TooltipProvider/TooltipProviderTypes.d.ts
@@ -1,4 +1,4 @@
-import type { MutableRefObject, ReactNode, RefObject } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import type { ITooltipController } from 'components/TooltipController/TooltipControllerTypes'
 
 export type AnchorRef = RefObject<HTMLElement>
@@ -18,7 +18,6 @@ export type TooltipContextDataWrapper = TooltipContextData & {
 
 export interface ITooltipWrapper {
   tooltipId?: string
-  forwardRef?: MutableRefObject<HTMLElement | null>
   children: ReactNode
 
   place?: ITooltipController['place']


### PR DESCRIPTION
`ReactNode` is less strict than `ReactElement`, allowing for more flexibility when using the `<TooltipWrapper />`.

See https://stackoverflow.com/a/58123882 for details