### PR TITLE
fix: add dep to the  context

### DIFF
--- a/src/components/TooltipProvider/TooltipProvider.tsx
+++ b/src/components/TooltipProvider/TooltipProvider.tsx
@@ -91,7 +91,7 @@ const TooltipProvider: React.FC<PropsWithChildren> = ({ children }) => {
       contextData,
     )
     return contextWrapper
-  }, [getTooltipData])
+  }, [getTooltipData, defaultTooltipId])
 
   return <TooltipContext.Provider value={context}>{children}</TooltipContext.Provider>
 }


### PR DESCRIPTION
I think it may not be a problem, but the useEffect depends on defaultTooltipId，adding it is more rigorous~~