### PR TITLE
Allow adjusting tooltip opacity using `style` prop

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, CSSProperties } from 'react'
 import classNames from 'classnames'
 import debounce from 'utils/debounce'
 import { TooltipContent } from 'components/TooltipContent'
@@ -203,15 +203,26 @@ const Tooltip = ({
     }
   }, [])
 
+  const style: CSSProperties = {
+    ...externalStyles,
+    ...inlineStyles,
+    visibility: 'hidden',
+    opacity: 0,
+  }
+  const shouldShow = content && !calculatingPosition && (isOpen || show)
+  if (shouldShow) {
+    style.opacity = externalStyles?.opacity ?? 0.9
+    style.visibility = 'visible'
+  }
+
   return (
     <WrapperElement
       id={id}
       role="tooltip"
       className={classNames(styles['tooltip'], styles[variant], className, {
-        [styles['show']]: content && !calculatingPosition && (isOpen || show),
         [styles['fixed']]: positionStrategy === 'fixed',
       })}
-      style={{ ...externalStyles, ...inlineStyles }}
+      style={style}
       ref={tooltipRef}
     >
       {children || (isHtmlContent ? <TooltipContent content={content as string} /> : content)}

--- a/src/components/Tooltip/styles.module.css
+++ b/src/components/Tooltip/styles.module.css
@@ -29,11 +29,6 @@
   display: none;
 }
 
-.show {
-  visibility: visible;
-  opacity: 0.9;
-}
-
 /** Types variant **/
 .dark {
   background: var(--rt-color-dark);

--- a/src/test/__snapshots__/index.spec.js.snap
+++ b/src/test/__snapshots__/index.spec.js.snap
@@ -10,7 +10,12 @@ exports[`tooltip props basic tooltip component 1`] = `
   <div
     className=""
     role="tooltip"
-    style={{}}
+    style={
+      {
+        "opacity": 0,
+        "visibility": "hidden",
+      }
+    }
   >
     Hello World!
     <div
@@ -31,7 +36,12 @@ exports[`tooltip props tooltip component - getContent 1`] = `
   <div
     className=""
     role="tooltip"
-    style={{}}
+    style={
+      {
+        "opacity": 0,
+        "visibility": "hidden",
+      }
+    }
   >
     Hello World!
     <div
@@ -52,7 +62,12 @@ exports[`tooltip props tooltip component - html 1`] = `
   <div
     className=""
     role="tooltip"
-    style={{}}
+    style={
+      {
+        "opacity": 0,
+        "visibility": "hidden",
+      }
+    }
   >
     <span
       dangerouslySetInnerHTML={
@@ -77,7 +92,12 @@ exports[`tooltip props tooltip component - without anchorId 1`] = `
   <div
     className=""
     role="tooltip"
-    style={{}}
+    style={
+      {
+        "opacity": 0,
+        "visibility": "hidden",
+      }
+    }
   >
     Hello World!
     <div
@@ -92,7 +112,12 @@ exports[`tooltip props tooltip component - without element reference 1`] = `
 <div
   className=""
   role="tooltip"
-  style={{}}
+  style={
+    {
+      "opacity": 0,
+      "visibility": "hidden",
+    }
+  }
 >
   <div
     className=""


### PR DESCRIPTION
This doesn't feel like a very elegant solution, but the only alternative I could think of was adding an `opacity` prop, and that seemed redundant as we already have the `style` prop.