### PR TITLE
Add `stale` GitHub action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '00 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 30
+        days-before-issue-close: 14
+        days-before-pr-stale: 30
+        days-before-pr-close: 14
+        stale-issue-message: 'This issue is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
+        stale-pr-message: 'This pull request is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
This should be fine since we're actively maintaining the repo. 

In the future we might want to disable auto-closing the issues.