### PR TITLE
fix: package main should be cjs format. (fixes #869)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepare": "husky install",
     "test": "jest"
   },
-  "main": "dist/react-tooltip.esm.min.js",
+  "main": "dist/react-tooltip.cjs.min.js",
+  "module": "dist/react-tooltip.esm.min.js",
   "buildFormats": [
     {
       "file": "dist/react-tooltip.umd.js",


### PR DESCRIPTION
Closes #869 

- Add module entry for esm in package.json

See https://rollupjs.org/guide/en/#publishing-es-modules:

> To make sure your ES modules are immediately usable by tools that work
> with CommonJS such as Node.js and webpack, you can use Rollup to
> compile to UMD or CommonJS format, and then point to that compiled
> version with the main property in your package.json file. If your
> package.json file also has a module field, ES-module-aware tools like
> Rollup and webpack 2+ will import the ES module version directly.