### PR TITLE
Fix package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import rimraf from 'rimraf'
+const fs = require('fs') // eslint-disable-line @typescript-eslint/no-var-requires
+const rimraf = require('rimraf') // eslint-disable-line @typescript-eslint/no-var-requires
 
 const args = process.argv.slice(2)
 const parameters = args.reduce((acc, arg) => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     }
   ],
   "types": "dist/react-tooltip.d.ts",
-  "type": "module",
   "license": "MIT",
   "private": false,
   "author": "ReactTooltip",


### PR DESCRIPTION
A fix for
- https://github.com/ReactTooltip/react-tooltip/issues/887
- https://github.com/ReactTooltip/react-tooltip/pull/881

> react-tooltip.cjs.min.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.