### PR TITLE
fix: replace useId with v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.0.4",
-    "classnames": "^2.3.2"
+    "@types/uuid": "^9.0.0",
+    "classnames": "^2.3.2",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/components/TooltipProvider/TooltipProvider.tsx
+++ b/src/components/TooltipProvider/TooltipProvider.tsx
@@ -3,10 +3,10 @@ import React, {
   PropsWithChildren,
   useCallback,
   useContext,
-  useId,
   useMemo,
   useState,
 } from 'react'
+import { v4 } from 'uuid'
 
 import type {
   AnchorRef,
@@ -32,7 +32,7 @@ const defaultContextWrapper = Object.assign(() => defaultContextData, defaultCon
 const TooltipContext = createContext<TooltipContextDataWrapper>(defaultContextWrapper)
 
 const TooltipProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const defaultTooltipId = useId()
+  const defaultTooltipId = v4()
   const [anchorRefMap, setAnchorRefMap] = useState<Record<string, Set<AnchorRef>>>({
     [defaultTooltipId]: new Set(),
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,6 +1191,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
+  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -8036,6 +8041,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
`useId` was introduced in React 18 but a lot of projects still use React 17.
to achieve backward compability we could replace useId with uuid.

This PR:
- replaces useId with uuid
