### PR TITLE
Fix `Middleware` type self-reference on build output

### DIFF
--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -1,5 +1,6 @@
 import type { ElementType, ReactNode, CSSProperties } from 'react'
-import type { Middleware } from '@floating-ui/dom'
+
+export type { Middleware } from '@floating-ui/dom'
 
 export type PlacesType = 'top' | 'right' | 'bottom' | 'left'
 
@@ -12,8 +13,6 @@ export type ChildrenType = Element | ElementType | ReactNode
 export type EventsType = 'hover' | 'click'
 
 export type PositionStrategy = 'absolute' | 'fixed'
-
-export type Middleware = Middleware
 
 export type DataAttribute =
   | 'place'

--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -1,6 +1,7 @@
 import type { ElementType, ReactNode, CSSProperties } from 'react'
+import type { Middleware } from '@floating-ui/dom'
 
-export type { Middleware } from '@floating-ui/dom'
+export type { Middleware }
 
 export type PlacesType = 'top' | 'right' | 'bottom' | 'left'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import type {
   VariantType,
   WrapperType,
   IPosition,
+  Middleware,
 } from './components/Tooltip/TooltipTypes'
 import type { ITooltipController } from './components/TooltipController/TooltipControllerTypes'
 import type { ITooltipWrapper } from './components/TooltipProvider/TooltipProviderTypes'
@@ -26,4 +27,5 @@ export type {
   ITooltipController as ITooltip,
   ITooltipWrapper,
   IPosition,
+  Middleware,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["./global.d.ts", "./src/**/*.ts", "./src/**/*.js", "./src/**/*.tsx"],
-  "exclude": [],
+  "exclude": ["src/test/**/*"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -104,6 +104,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": false /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
Closes #920.

This seems like a bug in rollup. The output `.d.ts` file does not include the `floating-ui` import, probably because rollup gets confused by using the exact same name for both types.

```ts
// Not included in the output
// import type { Middleware } from '@floating-ui/dom'
export type Middleware = Middleware
```
