### PR TITLE
Add new `anchorSelect` to improve how to attach multiple anchors to the same tooltip

### DIFF
--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -43,6 +43,7 @@ export interface ITooltip {
   id?: string
   variant?: VariantType
   anchorId?: string
+  anchorSelect?: string
   wrapper?: WrapperType
   children?: ChildrenType
   events?: EventsType[]

--- a/src/components/TooltipController/TooltipControllerTypes.d.ts
+++ b/src/components/TooltipController/TooltipControllerTypes.d.ts
@@ -21,6 +21,7 @@ export interface ITooltipController {
   id?: string
   variant?: VariantType
   anchorId?: string
+  anchorSelect?: string
   wrapper?: WrapperType
   children?: ChildrenType
   events?: EventsType[]


### PR DESCRIPTION
Turns out there might've been a much much easier way to do multiple anchors than using the provider. `anchorSelect` should be a CSS selector to find the anchor elements.

The aim of this pull request:
- [ ] Allow multiple anchor elements to the same tooltip using simply a CSS selector.
- [ ] If the provider/wrapper method doesn't prove to offer anything more than using selectors, we should deprecate it and point users to the `anchorSelect` prop (it's important to keep the API so code using the provider/wrapper still works).
- [ ] Warn in non-production environment if selector doesn't match anything/is invalid. Fail silently in production.
- [ ] ~~Find out why someone thought it would be a great idea to use providers when there was such a simpler alternative (this one's on me, sorry 😬)~~

I'm not so sure this will work well, but it's definitely worth a try.