### PR TITLE
fix: remove tooltip rendered element from DOM when is not showing

### DIFF
--- a/docs/docs/options.mdx
+++ b/docs/docs/options.mdx
@@ -109,8 +109,3 @@ import 'react-tooltip/dist/react-tooltip.css';
 | data-tooltip-show              | number  | false    |            | any `number`                                      | tooltip show will be delayed in miliseconds by the amount of value                                                                        |
 | data-tooltip-hide              | number  | false    |            | any `number`                                      | tooltip hide will be delayed in miliseconds by the amount of value                                                                        |
 | data-tooltip-float             | boolean | false    | `false`    | `true` `false`                                    | tooltip will follow the mouse position when it moves inside the anchor element (same as V4's `effect="float"`)                            |
-
-#### Observations
-
-- When using `data-tooltip-content` the `<br />` works by default
-- When using prop `content` the `<br />` doesn't work by default, use prop `html` instead of this

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     ]
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.0.4",
+    "@floating-ui/dom": "1.1.1",
     "classnames": "^2.3.2"
   }
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -46,7 +46,6 @@ const Tooltip = ({
   const [show, setShow] = useState(false)
   const [rendered, setRendered] = useState(false)
   const wasShowing = useRef(false)
-  const [calculatingPosition, setCalculatingPosition] = useState(false)
   const lastFloatPosition = useRef<IPosition | null>(null)
   const { anchorRefs, setActiveAnchor: setProviderActiveAnchor } = useTooltip(id)
   const [activeAnchor, setActiveAnchor] = useState<React.RefObject<HTMLElement>>({ current: null })
@@ -62,8 +61,8 @@ const Tooltip = ({
     setRendered(true)
 
     /**
-     * this `timeout` is necessary because the component
-     * needs to be rendered to calculate the position correctly
+     * wait for the component to render and calculate position
+     * before actually showing
      */
     setTimeout(() => {
       if (setIsOpen) {
@@ -132,7 +131,7 @@ const Tooltip = ({
   const handleHideTooltip = () => {
     if (clickable) {
       // allow time for the mouse to reach the tooltip, in case there's a gap
-      handleHideTooltipDelayed(delayHide || 50)
+      handleHideTooltipDelayed(delayHide || 100)
     } else if (delayHide) {
       handleHideTooltipDelayed()
     } else {
@@ -159,7 +158,6 @@ const Tooltip = ({
         }
       },
     } as Element
-    setCalculatingPosition(true)
     computeTooltipPosition({
       place,
       offset,
@@ -169,7 +167,6 @@ const Tooltip = ({
       strategy: positionStrategy,
       middlewares,
     }).then((computedStylesData) => {
-      setCalculatingPosition(false)
       if (Object.keys(computedStylesData.tooltipStyles).length) {
         setInlineStyles(computedStylesData.tooltipStyles)
       }
@@ -350,7 +347,6 @@ const Tooltip = ({
       // `anchorId` element takes precedence
       elementReference = document.querySelector(`[id='${anchorId}']`) as HTMLElement
     }
-    setCalculatingPosition(true)
     let mounted = true
     computeTooltipPosition({
       place,
@@ -365,7 +361,6 @@ const Tooltip = ({
         // invalidate computed positions after remount
         return
       }
-      setCalculatingPosition(false)
       if (Object.keys(computedStylesData.tooltipStyles).length) {
         setInlineStyles(computedStylesData.tooltipStyles)
       }
@@ -402,10 +397,7 @@ const Tooltip = ({
 
   const hasContentOrChildren = Boolean(html || content || children)
   const canShow = Boolean(
-    hasContentOrChildren &&
-      !calculatingPosition &&
-      (isOpen || show) &&
-      Object.keys(inlineStyles).length > 0,
+    hasContentOrChildren && (isOpen || show) && Object.keys(inlineStyles).length > 0,
   )
 
   return rendered ? (

--- a/src/test/__snapshots__/index.spec.js.snap
+++ b/src/test/__snapshots__/index.spec.js.snap
@@ -1,123 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tooltip attributes basic tooltip component 1`] = `
+<span
+  data-tooltip-content="Hello World!"
+  id="basic-example-attr"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip attributes tooltip component - delayHide 1`] = `
+<span
+  data-tooltip-content="Hello World!"
+  data-tooltip-delay-hide={1000}
+  id="basic-example-delay-hide-attr"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip attributes tooltip component - delayShow 1`] = `
+<span
+  data-tooltip-content="Hello World!"
+  data-tooltip-delay-show={1000}
+  id="basic-example-delay-show-attr"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip attributes tooltip component - html 1`] = `
+<span
+  data-tooltip-html="Hello World!"
+  data-tooltip-place="top"
+  data-tooltip-variant="info"
+  id="basic-example-html-attr"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip attributes tooltip component - without anchorId 1`] = `
+<span
+  data-tooltip-content="Hello World!"
+>
+  Lorem Ipsum
+</span>
+`;
+
 exports[`tooltip props basic tooltip component 1`] = `
-[
-  <span
-    id="basic-example"
-  >
-    Lorem Ipsum
-  </span>,
-  <div
-    className="react-tooltip"
-    role="tooltip"
-    style={{}}
-  >
-    Hello World!
-    <div
-      className="react-tooltip-arrow"
-      style={{}}
-    />
-  </div>,
-]
+<span
+  id="basic-example"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip props tooltip component - delayHide 1`] = `
+<span
+  id="basic-example-delay-hide"
+>
+  Lorem Ipsum
+</span>
+`;
+
+exports[`tooltip props tooltip component - delayShow 1`] = `
+<span
+  id="basic-example-delay-show"
+>
+  Lorem Ipsum
+</span>
 `;
 
 exports[`tooltip props tooltip component - getContent 1`] = `
-[
-  <span
-    id="basic-example-get-content"
-  >
-    Lorem Ipsum
-  </span>,
-  <div
-    className="react-tooltip"
-    role="tooltip"
-    style={{}}
-  >
-    Hello World!
-    <div
-      className="react-tooltip-arrow"
-      style={{}}
-    />
-  </div>,
-]
+<span
+  id="basic-example-get-content"
+>
+  Lorem Ipsum
+</span>
 `;
 
 exports[`tooltip props tooltip component - html 1`] = `
-[
-  <span
-    id="basic-example-html"
-  >
-    Lorem Ipsum
-  </span>,
-  <div
-    className="react-tooltip"
-    role="tooltip"
-    style={{}}
-  >
-    <span
-      dangerouslySetInnerHTML={
-        {
-          "__html": "Hello World!",
-        }
-      }
-    />
-    <div
-      className="react-tooltip-arrow"
-      style={{}}
-    />
-  </div>,
-]
+<span
+  id="basic-example-html"
+>
+  Lorem Ipsum
+</span>
 `;
 
 exports[`tooltip props tooltip component - position props 1`] = `
-[
-  <span
-    id="position-props"
-  >
-    Lorem Ipsum
-  </span>,
-  <div
-    className="react-tooltip"
-    role="tooltip"
-    style={{}}
-  >
-    Hello World!
-    <div
-      className="react-tooltip-arrow"
-      style={{}}
-    />
-  </div>,
-]
+<span
+  id="position-props"
+>
+  Lorem Ipsum
+</span>
 `;
 
 exports[`tooltip props tooltip component - without anchorId 1`] = `
-[
-  <span>
-    Lorem Ipsum
-  </span>,
-  <div
-    className="react-tooltip"
-    role="tooltip"
-    style={{}}
-  >
-    Hello World!
-    <div
-      className="react-tooltip-arrow"
-      style={{}}
-    />
-  </div>,
-]
+<span>
+  Lorem Ipsum
+</span>
 `;
 
-exports[`tooltip props tooltip component - without element reference 1`] = `
-<div
-  className="react-tooltip"
-  role="tooltip"
-  style={{}}
->
-  <div
-    className="react-tooltip-arrow"
-    style={{}}
-  />
-</div>
-`;
+exports[`tooltip props tooltip component - without element reference 1`] = `null`;

--- a/src/test/index.spec.js
+++ b/src/test/index.spec.js
@@ -4,7 +4,7 @@ import { computeTooltipPosition } from 'utils/compute-positions'
 import { TooltipController as Tooltip } from '../components/TooltipController'
 
 // Tell Jest to mock all timeout functions
-jest.useFakeTimers()
+jest.useRealTimers()
 
 // eslint-disable-next-line react/prop-types
 const TooltipProps = ({ id, ...tooltipParams }) => (
@@ -208,6 +208,8 @@ describe('compute positions', () => {
 })
 
 describe('debounce', () => {
+  jest.useFakeTimers()
+
   let func
   let debouncedFunc
 

--- a/src/test/index.spec.js
+++ b/src/test/index.spec.js
@@ -13,6 +13,15 @@ const TooltipProps = ({ id, ...tooltipParams }) => (
     <Tooltip anchorId={id} {...tooltipParams} />
   </>
 )
+// eslint-disable-next-line react/prop-types
+const TooltipAttrs = ({ id, ...anchorParams }) => (
+  <>
+    <span id={id} {...anchorParams}>
+      Lorem Ipsum
+    </span>
+    <Tooltip anchorId={id} />
+  </>
+)
 
 describe('tooltip props', () => {
   test('tooltip component - without anchorId', () => {
@@ -55,9 +64,78 @@ describe('tooltip props', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('tooltip component - delayShow', () => {
+    const component = renderer.create(
+      <TooltipProps id="basic-example-delay-show" content="Hello World!" delayShow={1000} />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('tooltip component - delayHide', () => {
+    const component = renderer.create(
+      <TooltipProps id="basic-example-delay-hide" content="Hello World!" delayHide={1000} />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   test('tooltip component - position props', () => {
     const component = renderer.create(
       <TooltipProps id="position-props" content="Hello World!" position={{ x: 0, y: 0 }} />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('tooltip attributes', () => {
+  test('tooltip component - without anchorId', () => {
+    const component = renderer.create(<TooltipAttrs data-tooltip-content="Hello World!" />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('basic tooltip component', () => {
+    const component = renderer.create(
+      <TooltipAttrs id="basic-example-attr" data-tooltip-content="Hello World!" />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('tooltip component - html', () => {
+    const component = renderer.create(
+      <TooltipAttrs
+        id="basic-example-html-attr"
+        data-tooltip-html="Hello World!"
+        data-tooltip-variant="info"
+        data-tooltip-place="top"
+      />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('tooltip component - delayShow', () => {
+    const component = renderer.create(
+      <TooltipAttrs
+        id="basic-example-delay-show-attr"
+        data-tooltip-content="Hello World!"
+        data-tooltip-delay-show={1000}
+      />,
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('tooltip component - delayHide', () => {
+    const component = renderer.create(
+      <TooltipAttrs
+        id="basic-example-delay-hide-attr"
+        data-tooltip-content="Hello World!"
+        data-tooltip-delay-hide={1000}
+      />,
     )
     const tree = component.toJSON()
     expect(tree).toMatchSnapshot()
@@ -122,7 +200,7 @@ describe('compute positions', () => {
         top: '',
       },
       tooltipStyles: {
-        left: '-5px',
+        left: '5px',
         top: '-10px',
       },
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,17 +403,17 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@floating-ui/core@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.2.tgz#d06a66d3ad8214186eda2432ac8b8d81868a571f"
-  integrity sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==
+"@floating-ui/core@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.1.tgz#cf8b4cdd8987c687329a6099561764d8a16f2f22"
+  integrity sha512-PL7g3dhA4dHgZfujkuD8Q+tfJJynEtnNQSPzmucCnxMvkxf4cLBJw/ZYqZUn4HCh33U3WHrAfv2R2tbi9UCSmw==
 
-"@floating-ui/dom@^1.0.4":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.6.tgz#e42393ec381a4fe96673fbcee137a95e86c93ebc"
-  integrity sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==
+"@floating-ui/dom@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.1.tgz#66aa747e15894910869bf9144fc54fc7d6e9f975"
+  integrity sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==
   dependencies:
-    "@floating-ui/core" "^1.0.2"
+    "@floating-ui/core" "^1.1.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"


### PR DESCRIPTION
- [x] fix the tooltip `first show` when the element is not rendered (the position was miscalculated)
- [x] stay with the same behaviors in this PR as before

closes #918 