### PR TITLE
Fix some bugs and general tooltip behavior

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -361,6 +361,7 @@ const Tooltip = ({
         }
         return [...mutation.removedNodes].some((node) => {
           if (node.contains(activeAnchor)) {
+            setRendered(false)
             handleShow(false)
             setActiveAnchor(null)
             return true


### PR DESCRIPTION
- [X] `setRendered(false)` when anchor element gets removed from the DOM
- [X] `setShow(true)` only after finishing calculating position
- [X] Wait to close the tooltip so it doesn't fade back in when quickly switch between anchors
- [ ] Fix behavior when using `isOpen`/`setIsOpen`

When using timeout, the tooltip might still get shown before calculating the position.
Instead of using a timeout, render the tooltip and wait for the position calculation to finish.

