### PR TITLE
Remove floating-ui exports to improve bundlesize

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,15 +2,15 @@
   "files": [
     {
       "path": "./dist/react-tooltip.cjs.min.js",
-      "maxSize": "14.5 kB"
+      "maxSize": "13.5 kB"
     },
     {
       "path": "./dist/react-tooltip.esm.min.js",
-      "maxSize": "14.5 kB"
+      "maxSize": "13.5 kB"
     },
     {
       "path": "./dist/react-tooltip.umd.min.js",
-      "maxSize": "14.5 kB"
+      "maxSize": "13.5 kB"
     }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@
 import { TooltipController as Tooltip } from 'components/TooltipController'
 import { IPosition } from 'components/Tooltip/TooltipTypes.d'
 import { useState } from 'react'
+import { inline, offset } from '@floating-ui/dom'
 import styles from './styles.module.css'
-import { inline, offset } from './index'
 
 function App() {
   const [anchorId, setAnchorId] = useState('button')

--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -1,7 +1,4 @@
 import type { ElementType, ReactNode, CSSProperties } from 'react'
-import type { Middleware } from '@floating-ui/dom'
-
-export type { Middleware }
 
 export type PlacesType = 'top' | 'right' | 'bottom' | 'left'
 
@@ -27,6 +24,12 @@ export type DataAttribute =
   | 'delay-show'
   | 'delay-hide'
   | 'float'
+
+/**
+ * @description floating-ui middleware
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Middleware = any
 
 export interface IPosition {
   x: number

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,6 @@ import type {
 import type { ITooltipController } from './components/TooltipController/TooltipControllerTypes'
 import type { ITooltipWrapper } from './components/TooltipProvider/TooltipProviderTypes'
 
-export { offset, inline, shift, flip, autoPlacement, size } from '@floating-ui/dom'
 export { TooltipController as Tooltip } from './components/TooltipController'
 export { TooltipProvider, TooltipWrapper } from './components/TooltipProvider'
 export type {


### PR DESCRIPTION
We don't even have it on the documentation that you can import the middlewares directly from the package.
If needed, the middlewares can be imported directly from `@floating-ui/dom`.
