### PR TITLE
Add external deps rollup plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-html-scaffold": "^0.2.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
     "rollup-plugin-progress": "^1.1.2",
     "rollup-plugin-string": "^3.0.0",

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -7,6 +7,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 import ts from '@rollup/plugin-typescript'
 import { terser } from 'rollup-plugin-terser'
 import typescript from 'typescript'
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import pkg from './package.json'
 
 const input = ['src/index.tsx']
@@ -77,14 +78,14 @@ const pluginsForCSSMinification = [
 const defaultOutputData = pkg.buildFormats.map(({ file, format }) => ({
   file,
   format,
-  plugins: [...plugins, filesize()],
+  plugins: [peerDepsExternal(), ...plugins, filesize()],
 }))
 
 // this step is just to build the minified css and es modules javascript
 const minifiedOutputData = pkg.buildFormats.map(({ file, format }) => ({
   file: file.replace('.js', '.min.js'),
   format,
-  plugins: [...pluginsForCSSMinification, terser(), filesize()],
+  plugins: [peerDepsExternal(), ...pluginsForCSSMinification, terser(), filesize()],
 }))
 
 const outputData = [...defaultOutputData, ...minifiedOutputData]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7168,6 +7168,11 @@ rollup-plugin-html-scaffold@^0.2.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-html-scaffold/-/rollup-plugin-html-scaffold-0.2.0.tgz#10c9278ec7dc83e2ee069d6de9988b98d8afa5f2"
   integrity sha512-YklCL0amFzdrevcA+HELwMld5ih52aaHEGXeiS8hue+ZVCTziUDz0eVWQTNY1CogobgEtWV/EtXQNSGBbMRPwQ==
 
+rollup-plugin-peer-deps-external@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
+  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+
 rollup-plugin-postcss@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz#15e9462f39475059b368ce0e49c800fa4b1f7050"


### PR DESCRIPTION
Adding the plugin without with default configurations seems to work fine.

Is there a reason we shouldn't do this?

Sample project: https://stackblitz.com/edit/react-ts-22ya1r?file=App.tsx,package.json
Bundlephobia: https://bundlephobia.com/package/react-tooltip@5.8.2-beta.4

![image](https://user-images.githubusercontent.com/21102974/220674764-d084c8d0-5f41-460c-893a-e05f3c200fde.png)
