### PR TITLE
chore: make dependencies external

### DIFF
--- a/esbuild.config.prod.mjs
+++ b/esbuild.config.prod.mjs
@@ -1,6 +1,7 @@
 import * as esbuild from 'esbuild'
 import cssModulesPlugin from 'esbuild-css-modules-plugin'
 import fs from 'fs'
+import pkg from './package.json' assert { type: 'json' }
 
 const buildsConfig = [
   {
@@ -44,6 +45,7 @@ const buildsConfig = [
     minify: true,
   },
 ]
+const externals = Object.keys({ ...(pkg.peerDependencies ?? {}), ...(pkg.dependencies ?? {}) })
 
 const builds = await Promise.all(
   buildsConfig.map(({ format, outfile, minify }) =>
@@ -55,7 +57,7 @@ const builds = await Promise.all(
       treeShaking: true,
       minify,
       sourcemap: true,
-      external: ['react', 'react-dom', 'prop-types'],
+      external: externals,
       plugins: [
         cssModulesPlugin({
           // inject: true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "postcss": "8.4.21",
     "prettier": "2.8.4",
     "process": "^0.11.10",
-    "prop-types": ">=15.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "rimraf": "^3.0.2",
@@ -100,7 +99,6 @@
   "peerDependencies": {
     "@floating-ui/dom": "^1.0.0",
     "classnames": "^2.3.0",
-    "prop-types": ">=15.0.0",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/ReactTooltip/react-tooltip#readme",
   "devDependencies": {
+    "@floating-ui/dom": "^1.0.0",
     "@rollup/plugin-commonjs": "22.0.2",
     "@rollup/plugin-node-resolve": "14.1.0",
     "@rollup/plugin-replace": "4.0.0",
@@ -52,6 +53,7 @@
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
     "bundlesize": "^0.18.1",
+    "classnames": "^2.3.0",
     "css-loader": "6.7.3",
     "esbuild": "0.17.11",
     "esbuild-css-modules-plugin": "^2.7.1",
@@ -71,7 +73,7 @@
     "postcss": "8.4.21",
     "prettier": "2.8.4",
     "process": "^0.11.10",
-    "prop-types": "^15.7.2",
+    "prop-types": ">=15.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "rimraf": "^3.0.2",
@@ -96,6 +98,9 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
+    "@floating-ui/dom": "^1.0.0",
+    "classnames": "^2.3.0",
+    "prop-types": ">=15.0.0",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0"
   },
@@ -110,9 +115,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "dependencies": {
-    "@floating-ui/dom": "1.2.3",
-    "classnames": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/ReactTooltip/react-tooltip#readme",
   "devDependencies": {
-    "@floating-ui/dom": "^1.0.0",
     "@rollup/plugin-commonjs": "22.0.2",
     "@rollup/plugin-node-resolve": "14.1.0",
     "@rollup/plugin-replace": "4.0.0",
@@ -53,7 +52,6 @@
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
     "bundlesize": "^0.18.1",
-    "classnames": "^2.3.0",
     "css-loader": "6.7.3",
     "esbuild": "0.17.11",
     "esbuild-css-modules-plugin": "^2.7.1",
@@ -97,8 +95,6 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@floating-ui/dom": "^1.0.0",
-    "classnames": "^2.3.0",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0"
   },
@@ -113,5 +109,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.0.0",
+    "classnames": "^2.3.0"
   }
 }


### PR DESCRIPTION
Closes #974 

Dependencies used at runtime were moved in peer dependencies. Package.json is read in order to extract dependencies to make external.

Size changes results
| File | Before | After |
|-|-|-|
react-tooltip.cjs.js | 51K | 31K
react-tooltip.cjs.js.map | 95K | 53K
react-tooltip.cjs.min.js | 26K | 13K
react-tooltip.cjs.min.js.map | 96K | 55K
react-tooltip.css | 1.7K | 1.7K
react-tooltip.css.map | 1.7K | 1.7K
react-tooltip.esm.js | 50K | 28K
react-tooltip.esm.js.map | 95K | 52K
react-tooltip.esm.min.js | 26K | 11K
react-tooltip.esm.min.js.map | 96K | 54K
react-tooltip.iife.js | 54K | 32K
react-tooltip.iife.js.map | 95K | 52K
react-tooltip.iife.min.js | 26K | 13K
react-tooltip.iife.min.js.map | 95K | 54K
react-tooltip.min.js | 26K | 11K
react-tooltip.min.js.map | 96K | 54K

---

This PR is marked as draft because I could not get `example-v5` to work from main in order to tweak it and compare its dist bundle in situ. I could use some help just to make sure `example-v5` works correctly before the PR