### PR TITLE
Add `styles` and `render` as dependencies for the position calculation effect

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -34,7 +34,7 @@ const Tooltip = ({
   afterHide,
   // props handled by controller
   content,
-  contentRef,
+  contentWrapperRef,
   isOpen,
   setIsOpen,
   activeAnchor,
@@ -476,21 +476,17 @@ const Tooltip = ({
   }, [show, activeAnchor, content, externalStyles, place, offset, positionStrategy, position])
 
   useEffect(() => {
-    if (!contentRef?.current) {
+    if (!contentWrapperRef?.current) {
       return () => null
     }
-    const contentObserver = new MutationObserver(() => {
+    const contentObserver = new ResizeObserver(() => {
       updateTooltipPosition()
     })
-    contentObserver.observe(contentRef.current, {
-      attributes: true,
-      childList: true,
-      subtree: true,
-    })
+    contentObserver.observe(contentWrapperRef.current)
     return () => {
       contentObserver.disconnect()
     }
-  }, [content, contentRef?.current])
+  }, [content, contentWrapperRef?.current])
 
   useEffect(() => {
     const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -468,7 +468,7 @@ const Tooltip = ({
       }
       setActualPlacement(computedStylesData.place as PlacesType)
     })
-  }, [show, activeAnchor, content, place, offset, positionStrategy, position])
+  }, [show, activeAnchor, content, externalStyles, place, offset, positionStrategy, position])
 
   useEffect(() => {
     const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -34,6 +34,7 @@ const Tooltip = ({
   afterHide,
   // props handled by controller
   content,
+  contentRef,
   isOpen,
   setIsOpen,
   activeAnchor,
@@ -425,7 +426,7 @@ const Tooltip = ({
     }
   }, [id, anchorSelect, activeAnchor])
 
-  useEffect(() => {
+  const updateTooltipPosition = () => {
     if (position) {
       // if `position` is set, override regular and `float` positioning
       handleTooltipPosition(position)
@@ -468,7 +469,28 @@ const Tooltip = ({
       }
       setActualPlacement(computedStylesData.place as PlacesType)
     })
+  }
+
+  useEffect(() => {
+    updateTooltipPosition()
   }, [show, activeAnchor, content, externalStyles, place, offset, positionStrategy, position])
+
+  useEffect(() => {
+    if (!contentRef?.current) {
+      return () => null
+    }
+    const contentObserver = new MutationObserver(() => {
+      updateTooltipPosition()
+    })
+    contentObserver.observe(contentRef.current, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    })
+    return () => {
+      contentObserver.disconnect()
+    }
+  }, [content, contentRef?.current])
 
   useEffect(() => {
     const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)

--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -40,7 +40,7 @@ export interface ITooltip {
   className?: string
   classNameArrow?: string
   content?: ChildrenType
-  contentRef?: RefObject<HTMLElement>
+  contentWrapperRef?: RefObject<HTMLDivElement>
   place?: PlacesType
   offset?: number
   id?: string

--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -1,4 +1,4 @@
-import type { ElementType, ReactNode, CSSProperties } from 'react'
+import type { ElementType, ReactNode, CSSProperties, RefObject } from 'react'
 
 export type PlacesType = 'top' | 'right' | 'bottom' | 'left'
 
@@ -40,6 +40,7 @@ export interface ITooltip {
   className?: string
   classNameArrow?: string
   content?: ChildrenType
+  contentRef?: RefObject<HTMLElement>
   place?: PlacesType
   offset?: number
   id?: string

--- a/src/components/TooltipController/TooltipController.tsx
+++ b/src/components/TooltipController/TooltipController.tsx
@@ -205,9 +205,13 @@ const TooltipController = ({
    * children should be lower priority so that it can be used as the "default" content
    */
   let renderedContent: ChildrenType = children
-  const contentRef = useRef<HTMLElement>(null)
+  const contentWrapperRef = useRef<HTMLDivElement>(null)
   if (render) {
-    renderedContent = render({ ref: contentRef, content: tooltipContent ?? null, activeAnchor })
+    renderedContent = (
+      <div ref={contentWrapperRef} className="react-tooltip-content-wrapper">
+        {render({ content: tooltipContent ?? null, activeAnchor }) as React.ReactNode}
+      </div>
+    )
   } else if (tooltipContent) {
     renderedContent = tooltipContent
   }
@@ -222,7 +226,7 @@ const TooltipController = ({
     className,
     classNameArrow,
     content: renderedContent,
-    contentRef,
+    contentWrapperRef,
     place: tooltipPlace,
     variant: tooltipVariant,
     offset: tooltipOffset,

--- a/src/components/TooltipController/TooltipController.tsx
+++ b/src/components/TooltipController/TooltipController.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Tooltip } from 'components/Tooltip'
 import type {
   EventsType,
@@ -205,8 +205,9 @@ const TooltipController = ({
    * children should be lower priority so that it can be used as the "default" content
    */
   let renderedContent: ChildrenType = children
+  const contentRef = useRef<HTMLElement>(null)
   if (render) {
-    renderedContent = render({ content: tooltipContent ?? null, activeAnchor })
+    renderedContent = render({ ref: contentRef, content: tooltipContent ?? null, activeAnchor })
   } else if (tooltipContent) {
     renderedContent = tooltipContent
   }
@@ -221,6 +222,7 @@ const TooltipController = ({
     className,
     classNameArrow,
     content: renderedContent,
+    contentRef,
     place: tooltipPlace,
     variant: tooltipVariant,
     offset: tooltipOffset,

--- a/src/components/TooltipController/TooltipControllerTypes.d.ts
+++ b/src/components/TooltipController/TooltipControllerTypes.d.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, RefObject } from 'react'
+import type { CSSProperties } from 'react'
 
 import type {
   PlacesType,
@@ -19,11 +19,7 @@ export interface ITooltipController {
    * @deprecated Use `children` or `render` instead
    */
   html?: string
-  render?: (render: {
-    ref: RefObject<HTMLElement>
-    content: string | null
-    activeAnchor: HTMLElement | null
-  }) => ChildrenType
+  render?: (render: { content: string | null; activeAnchor: HTMLElement | null }) => ChildrenType
   place?: PlacesType
   offset?: number
   id?: string

--- a/src/components/TooltipController/TooltipControllerTypes.d.ts
+++ b/src/components/TooltipController/TooltipControllerTypes.d.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, RefObject } from 'react'
 
 import type {
   PlacesType,
@@ -19,7 +19,11 @@ export interface ITooltipController {
    * @deprecated Use `children` or `render` instead
    */
   html?: string
-  render?: (render: { content: string | null; activeAnchor: HTMLElement | null }) => ChildrenType
+  render?: (render: {
+    ref: RefObject<HTMLElement>
+    content: string | null
+    activeAnchor: HTMLElement | null
+  }) => ChildrenType
   place?: PlacesType
   offset?: number
   id?: string


### PR DESCRIPTION
Closes #993.

A down side might be that if styles is passed inline like this:

```tsx
<Tooltip
  styles={{
    attr: value
  }}
/>
```

since the `styles` object will change on every render, the tooltip will recalculate its position on every render. 

That doesn't seem like a big deal, but is there a smart way to avoid this, besides forcing the user to wrap the object with `useMemo()` or something similar?

----

https://stackblitz.com/edit/react-ts-rtgmca

- [X] add `styles` as a dependency for the calculation
- [X] watch for attribute changes on the component passed through the `render` prop
