### PR TITLE
Fixed the `id` in the clickable tooltip example

### DIFF
--- a/docs/docs/examples/events.mdx
+++ b/docs/docs/examples/events.mdx
@@ -79,7 +79,7 @@ Clicking anywhere outside the anchor element will close the tooltip.
 import { Tooltip } from 'react-tooltip';
 import 'react-tooltip/dist/react-tooltip.css';
 
-<a data-tooltip-id="my-tooltip"> ◕‿‿◕ </a>
+<a data-tooltip-id="my-tooltip-click"> ◕‿‿◕ </a>
 <Tooltip 
   id="my-tooltip-click"
   content="Hello world!"


### PR DESCRIPTION
The id of the clickable example should be `my-tooltip-click` not `my-tooltip`