### PR TITLE
Fade-out transition when closing the tooltip

### DIFF
--- a/docs/docs/examples/styling.mdx
+++ b/docs/docs/examples/styling.mdx
@@ -381,7 +381,7 @@ If you wish to change the delay for any of them, override the following CSS vari
 
 Do not set `--rt-transition-closing-delay` to `0`. Doing so will result in the tooltip component being stuck (but not visible) on the DOM. This isn't itself a problem, but may lead to performance issues.
 
-Set to `1ms` or a similar value instead if you with to disable the fade-out transition when closing.
+Set to `1ms` or a similar value if you want to disable the fade-out transition when closing.
 
 :::
 

--- a/docs/docs/examples/styling.mdx
+++ b/docs/docs/examples/styling.mdx
@@ -372,6 +372,26 @@ In summary, if you do it correctly you can use CSS specificity instead of `!impo
 
 :::
 
+### Customizing opening/closing animation
+
+By default, the tooltip has a fade-in/fade-out transition when opening/closing, with a delay of 150ms for both.
+If you wish to change the delay for any of them, override the following CSS variables:
+
+:::caution
+
+Do not set `--rt-transition-closing-delay` to `0`. Doing so will result in the tooltip component being stuck (but not visible) on the DOM. This isn't itself a problem, but may lead to performance issues.
+
+Set to `1ms` or a similar value instead if you with to disable the fade-out transition when closing.
+
+:::
+
+```css
+:root {
+  --rt-transition-show-delay: 0.15s;
+  --rt-transition-closing-delay: 0.15s;
+}
+```
+
 ### Disabling ReactTooltip CSS
 
 ReactTooltip works seamlessly by automatically injecting CSS into your application. To disable this functionality, use the tooltip prop `disableStyleInjection`.

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -219,5 +219,7 @@ For advanced styling, check [the examples](./examples/styling.mdx).
   --rt-color-warning: #f0ad4e;
   --rt-color-info: #337ab7;
   --rt-opacity: 0.9;
+  --rt-transition-show-delay: 0.15s;
+  --rt-transition-closing-delay: 0.15s;
 }
 ```

--- a/src/components/Tooltip/core-styles.module.css
+++ b/src/components/Tooltip/core-styles.module.css
@@ -1,12 +1,10 @@
 .tooltip {
-  visibility: hidden;
   position: absolute;
   top: 0;
   left: 0;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s ease-out;
-  will-change: opacity, visibility;
+  will-change: opacity;
 }
 
 .fixed {
@@ -27,8 +25,13 @@
 }
 
 .show {
-  visibility: visible;
   opacity: var(--rt-opacity);
+  transition: opacity var(--rt-transition-show-delay) ease-out;
+}
+
+.closing {
+  opacity: 0;
+  transition: opacity var(--rt-transition-closing-delay) ease-in;
 }
 
 /** end - core styles **/

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -6,4 +6,6 @@
   --rt-color-warning: #f0ad4e;
   --rt-color-info: #337ab7;
   --rt-opacity: 0.9;
+  --rt-transition-show-delay: 0.15s;
+  --rt-transition-closing-delay: 0.15s;
 }


### PR DESCRIPTION
Closes #1105.

Reminder to link to https://react-tooltip.com/docs/examples/styling#customizing-openingclosing-animation on release notes.

Beta version `react-tooltip@5.22.0-beta.1106.0`