### PR TITLE
Force close when using `hidden` or empty `content`

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -710,9 +710,9 @@ const Tooltip = ({
     }
   }, [id, anchorSelect])
 
-  const canShow = !hidden && content && show && Object.keys(inlineStyles).length > 0
+  const canShow = show && Object.keys(inlineStyles).length > 0
 
-  return rendered ? (
+  return rendered && !hidden && content ? (
     <WrapperElement
       id={id}
       role="tooltip"


### PR DESCRIPTION
Closes #1114