### PR TITLE
Use `setTimeout()` for `ResizeObserver` callback

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -702,7 +702,7 @@ const Tooltip = ({
       return () => null
     }
     const contentObserver = new ResizeObserver(() => {
-      updateTooltipPosition()
+      setTimeout(() => updateTooltipPosition())
     })
     contentObserver.observe(contentWrapperRef.current)
     return () => {


### PR DESCRIPTION
Closes #1136.

Following suggestion from https://github.com/juggle/resize-observer/issues/103#issuecomment-1711148285

Beta version `react-tooltip@5.25.1-beta.1137.0`