### PR TITLE
Add fallback for tooltip internal state handling when `onTransitionEnd` never fires

### DIFF
--- a/docs/docs/examples/styling.mdx
+++ b/docs/docs/examples/styling.mdx
@@ -446,14 +446,6 @@ In summary, if you do it correctly you can use CSS specificity instead of `!impo
 By default, the tooltip has a fade-in/fade-out transition when opening/closing, with a delay of 150ms for both.
 If you wish to change the delay for any of them, override the following CSS variables:
 
-:::caution
-
-Do not set `--rt-transition-closing-delay` to `0`. Doing so will result in the tooltip component being stuck (but not visible) on the DOM. This isn't itself a problem, but may lead to performance issues.
-
-Set to `1ms` or a similar value if you want to disable the fade-out transition when closing.
-
-:::
-
 ```css
 :root {
   --rt-transition-show-delay: 0.15s;

--- a/src/utils/css-time-to-ms.ts
+++ b/src/utils/css-time-to-ms.ts
@@ -1,0 +1,11 @@
+export const cssTimeToMs = (time: string): number => {
+  const match = time.match(/^([\d.]+)(m?s?)$/)
+  if (!match) {
+    return 0
+  }
+  const [, amount, unit] = match
+  if (unit !== 's' && unit !== 'ms') {
+    return 0
+  }
+  return Number(amount) * (unit === 'ms' ? 1 : 1000)
+}


### PR DESCRIPTION
Closes #1144.

Also fixes bug with `--rt-transition-closing-delay: 0`.

Beta version `react-tooltip@5.25.1-beta.1145.0`