### PR TITLE
feat: add beta release workflow

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Setup git credentials
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'auto-release-bot@users.noreply.github.com'
+          git config --global user.name 'danielbarion'
+          git config --global user.email 'danielbarionn@gmail.com'
 
       - name: Get current package.json version
         run: echo "PACKAGE_VERSION=$(npm pkg get version)" >> $GITHUB_ENV

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -33,15 +33,8 @@ jobs:
       - name: Get current package.json version
         run: echo "PACKAGE_VERSION=$(npm pkg get version)" >> $GITHUB_ENV
 
-      - name: First beta release for this pull request
-        if: contains(env.PACKAGE_VERSION, 'beta') == false
-        run: echo "NEW_VERSION=$(npm version prerelease --no-git-tag-version --preid=beta.$GITHUB_PR_NUMBER)" >> $GITHUB_ENV
-        env:
-          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Subsequent beta releases for this pull request
-        if: contains(env.PACKAGE_VERSION, 'beta')
-        run: echo "NEW_VERSION=$(npm version prerelease --no-git-tag-version --preid=beta)" >> $GITHUB_ENV
+      - name: Setup Beta Release Version
+        run: node beta-release.js --issue $GITHUB_PR_NUMBER
         env:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
 
@@ -49,12 +42,6 @@ jobs:
         run: npm publish --tag beta
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Save new release version
-        run: |
-          git add ./package.json
-          git commit -m "chore: bump version to $NEW_VERSION"
-          git push
 
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -1,0 +1,76 @@
+name: Beta Release
+
+on:
+  workflow_call:
+
+jobs:
+  beta_release:
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install dev dependencies
+        run: yarn install
+
+      - name: Setup npm credentials file
+        run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> .npmrc
+
+      - name: Setup git credentials
+        run: |
+          git config --global user.name 'Auto Release Bot'
+          git config --global user.email 'auto-release-bot@users.noreply.github.com'
+
+      - name: Get current package.json version
+        run: echo "PACKAGE_VERSION=$(npm pkg get version)" >> $GITHUB_ENV
+
+      - name: First beta release for this pull request
+        if: contains(env.PACKAGE_VERSION, 'beta') == false
+        run: echo "NEW_VERSION=$(npm version prerelease --no-git-tag-version --preid=beta.$GITHUB_PR_NUMBER)" >> $GITHUB_ENV
+        env:
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Subsequent beta releases for this pull request
+        if: contains(env.PACKAGE_VERSION, 'beta')
+        run: echo "NEW_VERSION=$(npm version prerelease --no-git-tag-version --preid=beta)" >> $GITHUB_ENV
+        env:
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Release a new beta version
+        run: npm publish --tag beta
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Save new release version
+        run: |
+          git add ./package.json
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Beta version released with the last commit 🚀
+
+              \`\`\`
+              yarn add react-tooltip@${{ env.NEW_VERSION }}
+              \`\`\`
+              or
+              \`\`\`
+              npm install react-tooltip@${{ env.NEW_VERSION }}
+              \`\`\`
+              `
+            })

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Setup git credentials
         run: |
-          git config --global user.name 'danielbarion'
-          git config --global user.email 'danielbarionn@gmail.com'
+          git config --global user.name 'Auto Release Bot'
+          git config --global user.email 'auto-release-bot@users.noreply.github.com'
 
       - name: Get current package.json version
         run: echo "PACKAGE_VERSION=$(npm pkg get version)" >> $GITHUB_ENV
@@ -58,7 +58,6 @@ jobs:
 
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.DANIEL_TOKEN_AUTO_RELEASE_BOT }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.DANIEL_TOKEN_AUTO_RELEASE_BOT }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup git credentials
         run: |
-          git config --global user.name 'Auto Release Bot'
+          git config --global user.name 'github-actions[bot]'
           git config --global user.email 'auto-release-bot@users.noreply.github.com'
 
       - name: Get current package.json version

--- a/.github/workflows/bundlesize.yaml
+++ b/.github/workflows/bundlesize.yaml
@@ -1,4 +1,4 @@
-name: Run Bundlesize
+name: Bundlesize
 
 on:
   workflow_call:
@@ -7,8 +7,8 @@ jobs:
   bundlesize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
 
       - name: Install dev dependencies
         run: yarn install
@@ -18,4 +18,3 @@ jobs:
 
       - name: Bundlesize
         run: yarn run bundlesize
-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Run basic linting and testing
+name: Lint
 
 on:
   workflow_call:
@@ -7,8 +7,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
 
       - name: Install dev dependencies
         run: yarn install
@@ -20,11 +20,11 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        version: [16, 18]
+        version: [16, 18, 20]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,6 +16,11 @@ jobs:
     if: 'github.event.pull_request.draft == false'
     uses: ./.github/workflows/bundlesize.yaml
 
+  beta_release:
+    uses: ./.github/workflows/beta-release.yaml
+    # allow the children job to have access to the secrets of the repository
+    secrets: inherit
+
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true
     runs-on: ubuntu-18.04

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,27 +7,26 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '00 12 * * *'
+    - cron: '00 12 * * *'
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 90
-        days-before-issue-close: 30
-        days-before-pr-stale: 90
-        days-before-pr-close: 30
-        stale-issue-message: 'This issue is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
-        stale-pr-message: 'This pull request is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
-        exempt-issue-labels: 'help-wanted,v6'
-        exempt-pr-labels: 'help-wanted,v6'
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
+          stale-issue-message: 'This issue is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
+          stale-pr-message: 'This pull request is stale because it has not seen activity in 30 days. Remove the `stale` label or comment within 14 days, or it will be closed.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'help-wanted,v6'
+          exempt-pr-labels: 'help-wanted,v6'

--- a/beta-release.js
+++ b/beta-release.js
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+const package = require('./package.json')
+
+const args = require('minimist')(process.argv.slice(2))
+
+const issueNumber = args['issue']
+
+console.log(issueNumber)
+
+const runCommand = async (command) => {
+  return new Promise((resolve) => {
+    exec(command, (error, stdout, stderr) => {
+      resolve({ error, stdout, stderr })
+    })
+  })
+}
+
+const AutoBetaRelease = async () => {
+  // get all the versions of the package from npm
+  const { stdout } = await runCommand(`npm view . versions --json`)
+
+  // show npm published versions of this package
+  console.log(stdout)
+
+  // check if there is a beta release with the same issue number on published versions
+  const arrayOfBetaReleases = JSON.parse(stdout).filter((version) =>
+    version.includes(`${package.version}-beta.${issueNumber}`),
+  )
+
+  let fullLastBetaRelease = null
+
+  // if yes, get the latest beta release. Output: 1.0.0-beta.1.rc.0
+  if (arrayOfBetaReleases.length) {
+    fullLastBetaRelease = arrayOfBetaReleases[arrayOfBetaReleases.length - 1]
+  }
+
+  console.log('Last Beta Release: ', fullLastBetaRelease)
+
+  let nextBetaReleaseVersion = 0
+
+  if (fullLastBetaRelease) {
+    const lastBetaReleaseRCVersionArray = fullLastBetaRelease.match(/rc.+[0-9]+/g)
+
+    const lastBetaReleaseRCVersion =
+      lastBetaReleaseRCVersionArray && lastBetaReleaseRCVersionArray.length
+        ? lastBetaReleaseRCVersionArray[0]
+        : null
+
+    const lastBetaReleaseVersion = lastBetaReleaseRCVersion
+      ? lastBetaReleaseRCVersion.split('.')[1]
+      : 0
+
+    nextBetaReleaseVersion = parseInt(lastBetaReleaseVersion, 10) + 1
+  }
+
+  // next beta release version. Output: 1.0.0-beta.1.rc.1
+  const nextBetaReleaseVesionFull = `${package.version}-beta.${issueNumber}.rc.${nextBetaReleaseVersion}`
+
+  // update the beta version on package.json
+  const { error } = await runCommand(
+    `npm version ${nextBetaReleaseVesionFull} --no-git-tag-version`,
+  )
+
+  if (error) {
+    console.error(error)
+    return
+  }
+
+  // the beta version is already updated on package.json on the next line
+  console.log('Next Beta version: ', `${nextBetaReleaseVesionFull}`)
+
+  await runCommand(`echo "NEW_VERSION=${nextBetaReleaseVesionFull}" >> $GITHUB_ENV`)
+}
+
+AutoBetaRelease()

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest-environment-jsdom": "29.4.3",
     "jest-transform-css": "6.0.1",
     "lint-staged": "13.1.2",
+    "minimist": "^1.2.8",
     "postcss": "8.4.21",
     "prettier": "2.8.4",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5696,7 +5696,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
With the beta release workflow, all commits into the PR will trigger the beta release.

* the beta release always release a new beta version, following this format: 
`react-tooltip@{__VERSION__}-beta.{__PR_NUMBER__}.rc.{__BETA_VERSION__}` -> `react-tooltip@v0.0.11-beta.1.rc.1`
* to skip the workflow we need to add the following words to the commit message:
```
[skip ci]
[ci skip]
[no ci]
[skip actions]
[actions skip]
```

https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

<img width="991" alt="image" src="https://github.com/ReactTooltip/react-tooltip/assets/9615850/b5cbc94c-3c31-4460-bd55-d3890d37b6a3">

<img width="814" alt="image" src="https://github.com/ReactTooltip/react-tooltip/assets/9615850/3f484251-f368-42ce-8557-70d42db0cc0b">

https://www.npmjs.com/package/auto-beta-release?activeTab=versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated workflows for beta releases, enhancing the release process.
	- Updated Bundlesize GitHub Action to improve the reliability of bundle size checks.
	- Expanded node version support in linting workflow to include the latest version.
- **Enhancements**
	- Streamlined naming for linting workflow for better clarity.
- **Documentation**
	- Adjusted workflow documentation to reflect updated action versions and configurations.
- **Dependencies**
	- Added a new dependency (`minimist`) to improve command line parsing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->