### PR TITLE
Use `pointermove` event instead of `mousemove` for `float` mode.

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -338,7 +338,7 @@ const Tooltip = ({
     })
   }
 
-  const handleMouseMove = (event?: Event) => {
+  const handlePointerMove = (event?: Event) => {
     if (!event) {
       return
     }
@@ -546,8 +546,8 @@ const Tooltip = ({
 
     if (float) {
       enabledEvents.push({
-        event: 'mousemove',
-        listener: handleMouseMove,
+        event: 'pointermove',
+        listener: handlePointerMove,
       })
     }
 


### PR DESCRIPTION
Closes #1149.


Beta version `react-tooltip@5.25.2-beta.1149.0`
