### PR TITLE
Fix: remove anchor when `data-tooltip-id` gets changed

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -643,6 +643,9 @@ const Tooltip = ({
           const newId = (mutation.target as HTMLElement).getAttribute('data-tooltip-id')
           if (newId === id) {
             newAnchors.push(mutation.target as HTMLElement)
+          } else if (mutation.oldValue === id) {
+            // data-tooltip-id has now been changed, so we need to remove this anchor
+            removedAnchors.push(mutation.target as HTMLElement)
           }
         }
         if (mutation.type !== 'childList') {
@@ -727,6 +730,8 @@ const Tooltip = ({
       subtree: true,
       attributes: true,
       attributeFilter: ['data-tooltip-id'],
+      // to track the prev value if we need to remove anchor when data-tooltip-id gets changed
+      attributeOldValue: true,
     })
     return () => {
       documentObserver.disconnect()


### PR DESCRIPTION
When `data-tooltip-id` gets updated from `A` to `B` for the same DOM element, the `A` still continues showing the tooltip when it isn't expected. The PR fixes that, now `A` will properly untrack the tooltip when `data-tooltip-id` becomes not `A`

UPD: I see some failed tests. Looks like one test uses the outdated snapshot, the second one seems to be flaky. The same happens in `master` as well