### PR TITLE
Check if target is connected before handling click outside

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -357,6 +357,9 @@ const Tooltip = ({
       return
     }
     const target = event.target as HTMLElement
+    if (!target.isConnected) {
+      return
+    }
     if (tooltipRef.current?.contains(target)) {
       return
     }


### PR DESCRIPTION
Closes #1111.

As discussed on #1111, after thinking about it, it does feel like a bug.

Beta version `react-tooltip@5.26.1-beta.1170.0`

Check the example here: https://stackblitz.com/edit/stackblitz-starters-ehdav1
The tooltip closes when interacting with an element inside the tooltip when it unmounts upon being interacted with.

Fork and update the package version to `react-tooltip@5.26.1-beta.1170.0` and it should be fixed.