### PR TITLE
Update TooltipControllerTypes.d.ts

### DIFF
--- a/src/components/TooltipController/TooltipControllerTypes.d.ts
+++ b/src/components/TooltipController/TooltipControllerTypes.d.ts
@@ -17,11 +17,11 @@ import type {
 export interface ITooltipController {
   className?: string
   classNameArrow?: string
-  content?: string
+  content?: string | JSX.Element
   /**
    * @deprecated Use `children` or `render` instead
    */
-  html?: string
+  html?: string | JSX.Element
   render?: (render: { content: string | null; activeAnchor: HTMLElement | null }) => ChildrenType
   place?: PlacesType
   offset?: number


### PR DESCRIPTION
Allow JSX.Element in tooltip content and html props

- Update ITooltipController interface
- content and html props now accept string | JSX.Element
- Improves flexibility for adding React elements in TypeScript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tooltip content can now include JSX elements, allowing for richer and more dynamic tooltip displays.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->