### PR TITLE
Remove warning about styles already being injected

### DIFF
--- a/src/utils/handle-style.ts
+++ b/src/utils/handle-style.ts
@@ -52,13 +52,7 @@ function injectStyle({
   const { insertAt } = ref
 
   if (document.getElementById(id)) {
-    // this should never happen because of `injected[type]`
-    if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[react-tooltip] Element with id '${id}' already exists. Call \`removeStyle()\` first`,
-      )
-    }
+    // this could happen in cases the tooltip is imported by multiple js modules
     return
   }
 


### PR DESCRIPTION
Closes #1185.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of elements with duplicate IDs to prevent potential conflicts when the tooltip is imported by multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->