### PR TITLE
Clear timeout refs correctly

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   getScrollParent,
   computeTooltipPosition,
   cssTimeToMs,
+  clearTimeoutRef,
 } from 'utils'
 import type { IComputedPosition } from 'utils'
 import { useTooltip } from 'components/TooltipProvider'
@@ -223,9 +224,7 @@ const Tooltip = ({
     if (show === wasShowing.current) {
       return
     }
-    if (missedTransitionTimerRef.current) {
-      clearTimeout(missedTransitionTimerRef.current)
-    }
+    clearTimeoutRef(missedTransitionTimerRef)
     wasShowing.current = show
     if (show) {
       afterShow?.()
@@ -257,9 +256,7 @@ const Tooltip = ({
   }
 
   const handleShowTooltipDelayed = (delay = delayShow) => {
-    if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
-    }
+    clearTimeoutRef(tooltipShowDelayTimerRef)
 
     if (rendered) {
       // if the tooltip is already rendered, ignore delay
@@ -273,9 +270,7 @@ const Tooltip = ({
   }
 
   const handleHideTooltipDelayed = (delay = delayHide) => {
-    if (tooltipHideDelayTimerRef.current) {
-      clearTimeout(tooltipHideDelayTimerRef.current)
-    }
+    clearTimeoutRef(tooltipHideDelayTimerRef)
 
     tooltipHideDelayTimerRef.current = setTimeout(() => {
       if (hoveringTooltip.current) {
@@ -307,9 +302,7 @@ const Tooltip = ({
     setActiveAnchor(target)
     setProviderActiveAnchor({ current: target })
 
-    if (tooltipHideDelayTimerRef.current) {
-      clearTimeout(tooltipHideDelayTimerRef.current)
-    }
+    clearTimeoutRef(tooltipHideDelayTimerRef)
   }
 
   const handleHideTooltip = () => {
@@ -322,9 +315,7 @@ const Tooltip = ({
       handleShow(false)
     }
 
-    if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
-    }
+    clearTimeoutRef(tooltipShowDelayTimerRef)
   }
 
   const handleTooltipPosition = ({ x, y }: IPosition) => {
@@ -386,9 +377,7 @@ const Tooltip = ({
       return
     }
     handleShow(false)
-    if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
-    }
+    clearTimeoutRef(tooltipShowDelayTimerRef)
   }
 
   // debounce handler to prevent call twice when
@@ -697,12 +686,8 @@ const Tooltip = ({
               setRendered(false)
               handleShow(false)
               setActiveAnchor(null)
-              if (tooltipShowDelayTimerRef.current) {
-                clearTimeout(tooltipShowDelayTimerRef.current)
-              }
-              if (tooltipHideDelayTimerRef.current) {
-                clearTimeout(tooltipHideDelayTimerRef.current)
-              }
+              clearTimeoutRef(tooltipShowDelayTimerRef)
+              clearTimeoutRef(tooltipHideDelayTimerRef)
               return true
             }
             return false
@@ -790,12 +775,8 @@ const Tooltip = ({
       handleShow(true)
     }
     return () => {
-      if (tooltipShowDelayTimerRef.current) {
-        clearTimeout(tooltipShowDelayTimerRef.current)
-      }
-      if (tooltipHideDelayTimerRef.current) {
-        clearTimeout(tooltipHideDelayTimerRef.current)
-      }
+      clearTimeoutRef(tooltipShowDelayTimerRef)
+      clearTimeoutRef(tooltipHideDelayTimerRef)
     }
   }, [])
 
@@ -818,7 +799,11 @@ const Tooltip = ({
 
   useEffect(() => {
     if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
+      /**
+       * if the delay changes while the tooltip is waiting to show,
+       * reset the timer with the new delay
+       */
+      clearTimeoutRef(tooltipShowDelayTimerRef)
       handleShowTooltipDelayed(delayShow)
     }
   }, [delayShow])
@@ -875,9 +860,7 @@ const Tooltip = ({
         clickable && coreStyles['clickable'],
       )}
       onTransitionEnd={(event: TransitionEvent) => {
-        if (missedTransitionTimerRef.current) {
-          clearTimeout(missedTransitionTimerRef.current)
-        }
+        clearTimeoutRef(missedTransitionTimerRef)
         if (show || event.propertyName !== 'opacity') {
           return
         }

--- a/src/test/utils.spec.js
+++ b/src/test/utils.spec.js
@@ -1,4 +1,4 @@
-import { debounce, deepEqual, computeTooltipPosition, cssTimeToMs } from 'utils'
+import { debounce, deepEqual, computeTooltipPosition, cssTimeToMs, clearTimeoutRef } from 'utils'
 
 describe('compute positions', () => {
   test('empty reference elements', async () => {
@@ -254,5 +254,21 @@ describe('deepEqual', () => {
     const obj2 = { a: 1, b: [2, 4] }
 
     expect(deepEqual(obj1, obj2)).toBe(false)
+  })
+})
+
+describe('clearTimeoutRef', () => {
+  jest.useFakeTimers()
+
+  const func = jest.fn()
+
+  test('clears timeout ref', () => {
+    const timeoutRef = { current: setTimeout(func, 1000) }
+    clearTimeoutRef(timeoutRef)
+
+    jest.runAllTimers()
+
+    expect(func).not.toHaveBeenCalled()
+    expect(timeoutRef.current).toBe(null)
   })
 })

--- a/src/utils/clear-timeout-ref.ts
+++ b/src/utils/clear-timeout-ref.ts
@@ -1,0 +1,9 @@
+const clearTimeoutRef = (ref: React.MutableRefObject<NodeJS.Timeout | null>) => {
+  if (ref.current) {
+    clearTimeout(ref.current)
+    // eslint-disable-next-line no-param-reassign
+    ref.current = null
+  }
+}
+
+export default clearTimeoutRef

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ import debounce from './debounce'
 import deepEqual from './deep-equal'
 import getScrollParent from './get-scroll-parent'
 import useIsomorphicLayoutEffect from './use-isomorphic-layout-effect'
+import clearTimeoutRef from './clear-timeout-ref'
 
 export type { IComputedPosition }
 export {
@@ -16,4 +17,5 @@ export {
   deepEqual,
   getScrollParent,
   useIsomorphicLayoutEffect,
+  clearTimeoutRef,
 }


### PR DESCRIPTION
Closes #1182
Closes #1204.

See [comment here](https://github.com/ReactTooltip/react-tooltip/issues/1204#issuecomment-2204375576) for demo of issue.

See [same demo here](https://stackblitz.com/edit/vitejs-vite-bdkb2y?file=src%2FApp.tsx), fixed with beta release.

Keep in mind this change should not revert fix from #1168 (related to issue #1119, also see [sample code](https://codesandbox.io/p/sandbox/frosty-noether-y4m79q?file=%2Fsrc%2FApp.js)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tooltip reliability by using a custom timeout handler to prevent premature hiding or showing of tooltips.

- **Tests**
  - Added unit tests to ensure the new timeout handler functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->