### PR TITLE
Added enforceDelayShow prop. (Fixes #1235)

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -68,6 +68,7 @@ const Tooltip = ({
   border,
   opacity,
   arrowColor,
+  enforceDelayShow = false,
   role = 'tooltip',
 }: ITooltip) => {
   const tooltipRef = useRef<HTMLElement>(null)
@@ -259,7 +260,7 @@ const Tooltip = ({
   const handleShowTooltipDelayed = (delay = delayShow) => {
     clearTimeoutRef(tooltipShowDelayTimerRef)
 
-    if (rendered) {
+    if (rendered && !enforceDelayShow) {
       // if the tooltip is already rendered, ignore delay
       handleShow(true)
       return

--- a/src/components/Tooltip/TooltipTypes.d.ts
+++ b/src/components/Tooltip/TooltipTypes.d.ts
@@ -158,5 +158,6 @@ export interface ITooltip {
   border?: CSSProperties['border']
   opacity?: CSSProperties['opacity']
   arrowColor?: CSSProperties['backgroundColor']
+  enforceDelayShow?: boolean
   role?: React.AriaRole
 }


### PR DESCRIPTION
This will make the delayShow prop to always be enforced even if the tooltip instance is rendered.

This can be used for when you only have one tooltip instance, but multiple tooltip anchors, and want it to always take the delayShow amount of time before it is shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new prop `enforceDelayShow` for the `Tooltip` component, allowing users to control the display timing of tooltips with more precision.
- **Improvements**
	- Enhanced tooltip behavior to respect display delays even when previously rendered, providing a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->