### PR TITLE
Fix how hovering tooltip is handled to keep tooltip open

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -573,19 +573,21 @@ const Tooltip = ({
       })
     }
 
-    const handleMouseEnterTooltip = () => {
+    const handleMouseOverTooltip = () => {
       hoveringTooltip.current = true
     }
-    const handleMouseLeaveTooltip = () => {
+    const handleMouseOutTooltip = () => {
       hoveringTooltip.current = false
       handleHideTooltip()
     }
 
-    if (clickable && !hasClickEvent) {
-      // used to keep the tooltip open when hovering content.
-      // not needed if using click events.
-      tooltipRef.current?.addEventListener('mouseenter', handleMouseEnterTooltip)
-      tooltipRef.current?.addEventListener('mouseleave', handleMouseLeaveTooltip)
+    const addHoveringTooltipListeners =
+      clickable && (actualCloseEvents.mouseout || actualCloseEvents.mouseleave)
+    if (addHoveringTooltipListeners) {
+      // used to keep the tooltip open when hovering from anchor to tooltip.
+      // only relevant if either `mouseout`/`mouseleave` is in use
+      tooltipRef.current?.addEventListener('mouseover', handleMouseOverTooltip)
+      tooltipRef.current?.addEventListener('mouseout', handleMouseOutTooltip)
     }
 
     enabledEvents.forEach(({ event, listener }) => {
@@ -611,9 +613,9 @@ const Tooltip = ({
       if (actualGlobalCloseEvents.escape) {
         window.removeEventListener('keydown', handleEsc)
       }
-      if (clickable && !hasClickEvent) {
-        tooltipRef.current?.removeEventListener('mouseenter', handleMouseEnterTooltip)
-        tooltipRef.current?.removeEventListener('mouseleave', handleMouseLeaveTooltip)
+      if (addHoveringTooltipListeners) {
+        tooltipRef.current?.removeEventListener('mouseover', handleMouseOverTooltip)
+        tooltipRef.current?.removeEventListener('mouseout', handleMouseOutTooltip)
       }
       enabledEvents.forEach(({ event, listener }) => {
         elementRefs.forEach((ref) => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -147,15 +147,17 @@ const Tooltip = ({
 
   if (imperativeModeOnly) {
     Object.assign(actualOpenEvents, {
-      mouseenter: false,
+      mouseover: false,
       focus: false,
+      mouseenter: false,
       click: false,
       dblclick: false,
       mousedown: false,
     })
     Object.assign(actualCloseEvents, {
-      mouseleave: false,
+      mouseout: false,
       blur: false,
+      mouseleave: false,
       click: false,
       dblclick: false,
       mouseup: false,


### PR DESCRIPTION
Closes #1226

Reproducible here: https://codesandbox.io/p/sandbox/tooltip-forked-sh299h

Hovering opens the tooltip with imperative mode, but unhovering closes it, which shouldn't happen.

Fixed here (beta version installed): https://codesandbox.io/p/devbox/tooltip-forked-y8ndp6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced tooltip interactions by adjusting how hover events are managed. The tooltip now remains visible when moving between the trigger element and the tooltip itself, offering a smoother and more intuitive user experience. Event handling terminology has been updated for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->