### PR TITLE
Fix handling of click events when anchor has nested elements

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -515,8 +515,10 @@ const Tooltip = ({
 
     const enabledEvents: { event: string; listener: (event?: Event) => void }[] = []
 
+    const activeAnchorContainsTarget = (event?: Event): boolean =>
+      Boolean(event?.target && activeAnchor?.contains(event.target as HTMLElement))
     const handleClickOpenTooltipAnchor = (event?: Event) => {
-      if (show && event?.target === activeAnchor) {
+      if (show && activeAnchorContainsTarget(event)) {
         /**
          * ignore clicking the anchor that was used to open the tooltip.
          * this avoids conflict with the click close event.
@@ -526,7 +528,7 @@ const Tooltip = ({
       handleShowTooltip(event)
     }
     const handleClickCloseTooltipAnchor = (event?: Event) => {
-      if (!show || event?.target !== activeAnchor) {
+      if (!show || !activeAnchorContainsTarget(event)) {
         /**
          * ignore clicking the anchor that was NOT used to open the tooltip.
          * this avoids closing the tooltip when clicking on a


### PR DESCRIPTION
Closes #1220

Reproducible here: https://stackblitz.com/edit/stackblitz-starters-ggwyjh

Clicking E2 opens the tooltip, but clicking again does not close it.

