### PR TITLE
resolve --rt-transition-show-delay closer to tooltip for js timer

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -236,7 +236,7 @@ const Tooltip = ({
       /**
        * see `onTransitionEnd` on tooltip wrapper
        */
-      const style = getComputedStyle(document.body)
+      const style = getComputedStyle(tooltipRef.current || document.body)
       const transitionShowDelay = cssTimeToMs(style.getPropertyValue('--rt-transition-show-delay'))
       missedTransitionTimerRef.current = setTimeout(() => {
         /**


### PR DESCRIPTION
Changing `--rt-transition-show-delay` anywhere except in head or on body were not be picked up by show/hide timeouts causing out animations to be skipped entirely by removing the tooltip from the DOM when not using default positioned styles. This change evaluates the variable on the tooltip its self so that the property can be honored lower in the tree, which is already is for the animations, just not for the js timers.

Motivation: Using in a project intended to be embedded in other GUIs that should not modify the the DOM outside of its parent. I can't find a compelling reason why this computed style needs to be pinned to the document.body scope.

note: Either the naming of these variables are confusing or its possibly just using the wrong css variable here, `--rt-transition-show-delay` is used to delay unmounting when hiding and also to control the length of the default fade-in animation. It appears that this should really use `--rt-transition-closing-delay` as that's what dictates the length of the fade out duration. being new to the codebase I didn't want to make any assumptions but I'd be happy to change this as part of this PR if desired.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip animations now respect each tooltip’s own transition delay settings, ensuring consistent and predictable show/hide timing.
  * Resolves cases where custom theme or per-tooltip CSS variables were ignored, which could cause unexpected delays.
  * Improves visual consistency across different tooltips without changing overall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->