### PR TITLE
docs: enhance 'Clickable tooltip' section with accessibility info

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -179,9 +179,11 @@ import { Tooltip } from 'react-tooltip'
   <Tooltip anchorSelect=".my-anchor-element">Hello world!</Tooltip>
 </div>
 
-### Clickable tooltip
+### Clickable tooltip/accessibility
 
-By default, you can't interact with elements inside the tooltip. To allow for proper usage of elements such as buttons and inputs, use the `clickable` prop.
+By default the tooltip disappears when the pointer leaves the tooltip anchor element - which means you can't interact with elements inside the tooltip and that it won't meet the 'hoverable' requirement of [WCAG Success Criterion 1.4.13 Content on Hover or Focus](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus).
+
+To allow for proper usage of elements such as buttons and inputs - or to ensure the pointer can be moved over the tooltip content without it disappearing - use the `clickable` prop.
 
 ```jsx
 <a id="not-clickable">◕‿‿◕</a>


### PR DESCRIPTION
Updated the 'Clickable tooltip' section to include information about accessibility - see #1261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tooltip documentation to clarify hover behavior and accessibility requirements. Enhanced guidance on using the `clickable` prop to support interactive tooltip content while maintaining WCAG compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->