### PR TITLE
fix: keep clickable tooltips open while pointer moves to body

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -452,6 +452,7 @@ const Tooltip = ({
     lastFloatPosition,
     openEvents,
     openOnClick,
+    rendered,
     setActiveAnchor,
     show,
     tooltipHideDelayTimerRef,

--- a/src/components/Tooltip/use-tooltip-events.tsx
+++ b/src/components/Tooltip/use-tooltip-events.tsx
@@ -36,6 +36,7 @@ const useTooltipEvents = ({
   lastFloatPosition,
   openEvents,
   openOnClick,
+  rendered,
   setActiveAnchor,
   show,
   tooltipHideDelayTimerRef,
@@ -62,6 +63,7 @@ const useTooltipEvents = ({
   lastFloatPosition: RefObject<IPosition | null>
   openEvents?: AnchorOpenEvents
   openOnClick: boolean
+  rendered: boolean
   setActiveAnchor: (anchor: HTMLElement | null) => void
   show: boolean
   tooltipHideDelayTimerRef: RefObject<NodeJS.Timeout | null>
@@ -447,8 +449,10 @@ const useTooltipEvents = ({
       debouncedShow.cancel()
       debouncedHide.cancel()
     }
+    // `rendered` needs to be a dependency because `tooltipRef` becomes stale when the
+    // tooltip is removed from / added to the DOM.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actualOpenEvents, actualCloseEvents, float, clickable])
+  }, [actualOpenEvents, actualCloseEvents, float, clickable, rendered])
 
   // --- Effect 2: Global close events + auto-update ---
   // Re-runs when the global close config changes, or when the active anchor changes

--- a/src/test/tooltip-interaction-behavior.spec.js
+++ b/src/test/tooltip-interaction-behavior.spec.js
@@ -124,8 +124,12 @@ describe('tooltip interaction behavior', () => {
 
     unhoverAnchor(anchor, 0)
     fireEvent.mouseEnter(tooltip)
+    advanceTimers(150) // past clickable's 100ms hide-delay so the close timer fires
     await flushMicrotasks()
-    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+
+    const elem = screen.getByRole('tooltip')
+    expect(elem).toBeInTheDocument()
+    expect(elem).toHaveClass('react-tooltip__show')
 
     fireEvent.mouseLeave(tooltip)
     await flushMicrotasks()


### PR DESCRIPTION
## Summary

This fixes a regression bug, which appeared in v6.0.0

**Solution**: re-introduce `rendered` dependency on the effect that attaches the tooltip-body `mouseover`/`mouseout` listeners. Without it, clickable tooltips close as soon as the pointer leaves the anchor, making any interactive content inside the tooltip unreachable.

I have tested this solution with a local package using `npm link` and this change fixes the issue.

## Reproduction

Live sandbox: https://codesandbox.io/p/devbox/happy-tharp-g39qff

A clickable tooltip with content the user is supposed to interact with (e.g. an upgrade button):

```jsx
<TooltipController id="test-id" clickable>
  <button>Test</button>
</TooltipController>
<span data-tooltip-id="test-id">Test me</span>
```

Hover the anchor -> tooltip opens. Move the pointer toward the tooltip -> tooltip closes the moment the pointer leaves the anchor, before the user can reach the button.

## Root cause

The effect at `use-tooltip-events.tsx` attaches two listeners directly to the tooltip wrapper:

```js
tooltipElement?.addEventListener('mouseover', handleMouseOverTooltip)  // sets hoveringTooltip = true
tooltipElement?.addEventListener('mouseout',  handleMouseOutTooltip)   // sets hoveringTooltip = false
```

Those listeners are how the 100ms hide grace period (the one started when the pointer leaves the anchor) knows to suppress closing while the pointer is on the tooltip body.

The effect's deps array was `[actualOpenEvents, actualCloseEvents, float, clickable]`. None of those change between the initial mount and the moment the tooltip first becomes `rendered`. So the effect runs **once**, on mount, when `tooltipRef.current` is still `null` — the tooltip wrapper hasn't been committed to the DOM yet (`rendered` is `false`, `tooltipNode` is `null`). The optional chaining on `tooltipElement?.addEventListener(...)` silently no-ops, the listeners are never attached, and the effect never re-runs.

`hoveringTooltip.current` therefore stays `false` forever. The 100ms grace period always expires unsuppressed → tooltip closes the moment you leave the anchor.

## Fix

Add `rendered` to the deps array so the effect re-runs after `setRendered(true)` commits, when `tooltipRef.current` is now a real element. Listeners get attached. `hoveringTooltip` flips correctly.

## Test

There was already a test for this exact scenario — `keeps a clickable tooltip open while the pointer moves into it` in `tooltip-interaction-behavior.spec.js`. It was passing on broken code because of two compounding weaknesses, both of which had to be fixed for the test to be meaningful:

1. **No timer advancement.** The assertion fired right after `unhoverAnchor`, before the 100ms hide grace period could elapse. Whatever the listeners would or wouldn't have done, the timer hadn't fired yet — the test was just observing "tooltip exists immediately after starting close" which is true unconditionally. Now `advanceTimers(150)` past the hide-delay so the close path actually runs.
2. **Weak assertion.** Even after advancing time, `expect(...).toBeInTheDocument()` would still pass for a tooltip in the closing-but-not-yet-removed state (CSS transition is in progress, unmount happens via `onTransitionEnd`). To distinguish "still active" from "actively closing" the assertion needs to check for the `react-tooltip__show` class — switched to that, matching the convention in `tooltip-props.spec.js` and `tooltip-close-and-delay-behavior.spec.js`.

Verified that the strengthened test:
- fails on broken code with `Expected the element to have class react-tooltip__show`
- passes with the fix
- all other 169 tests still pass
- ESLint passes

## Regression history analysis

The dep was inadvertently dropped in [db420de9](https://github.com/ReactTooltip/react-tooltip/commit/db420de9) (Mar 2024, "chore: add hook rules to eslint and refactor relevant code"). That commit added `react-hooks/exhaustive-deps` and mechanically reorganized the deps array to satisfy it. ESLint can't see that `rendered` isn't a value used by the effect — it's a deliberate trigger to re-run when `tooltipRef.current` flips from `null` to a real element. The pre-existing comment that explained this exact intent...

> `rendered` is also a dependency to ensure anchor observers are re-registered since `tooltipRef` becomes stale after removing/adding the tooltip to the DOM

...was kept around the now-orphaned location for over a year, then finally cleaned up in [a24f389d](https://github.com/ReactTooltip/react-tooltip/commit/a24f389d) ("split events and anchors on it's own file") when the file was extracted. By v6 both the comment and the dep were gone.

The other two deps removed in db420de9 (`updateTooltipPosition`, `hasClickEvent`) **stay removed** — both have compensating refactors that make them redundant:

- `updateTooltipPosition` is now consumed via a ref-stable wrapper (`updateTooltipPositionRef.current()` in Effect 2), so capturing the latest callback doesn't require a re-run.
- `hasClickEvent` propagates transitively through `actualGlobalCloseEvents`'s `useMemo` deps.

`rendered` was the only dropped dep without compensation.

To prevent this from happening again on the next ESLint cleanup, this PR also adds an inline comment on the deps array explaining why `rendered` is there, alongside the existing `// eslint-disable-next-line react-hooks/exhaustive-deps`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip rendering state management to ensure tooltips properly respond to rendered state changes and pointer interactions.

* **Tests**
  * Enhanced tooltip interaction tests for more precise validation of display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->