### PR TITLE
fix: generated path inside sourcemaps

### DIFF
--- a/rollup.config.prod.mjs
+++ b/rollup.config.prod.mjs
@@ -126,10 +126,6 @@ const config = allBuildFormats.map(
         name,
         globals,
         sourcemap: true,
-        // Exclude the actual source content from the source map.
-        // This means that the source maps will contain references
-        // to positions in the original code, but not the source code itself.
-        sourcemapExcludeSources: true,
         // Fix source map paths: TypeScript plugin with rootDir="." generates
         // paths like ../../src/ (relative to intermediate dist/src/), but the
         // final bundle is at dist/, so paths should be ../src/.

--- a/rollup.config.prod.mjs
+++ b/rollup.config.prod.mjs
@@ -130,6 +130,11 @@ const config = allBuildFormats.map(
         // This means that the source maps will contain references
         // to positions in the original code, but not the source code itself.
         sourcemapExcludeSources: true,
+        // Fix source map paths: TypeScript plugin with rootDir="." generates
+        // paths like ../../src/ (relative to intermediate dist/src/), but the
+        // final bundle is at dist/, so paths should be ../src/.
+        sourcemapPathTransform: (relativeSourcePath) =>
+          relativeSourcePath.replace(/^(\.\.\/)+src\//, '../src/'),
         banner,
       },
       external,


### PR DESCRIPTION
closes #1272 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved source map path handling in production builds so source paths are normalized relative to the distributed output.
  * Restored inclusion of original source locations in production source maps to improve debugging and stack traces for generated files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReactTooltip/react-tooltip/pull/1273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->