### PR TITLE
fix: global events broke on ios

### DIFF
--- a/src/components/Tooltip/use-tooltip-events.tsx
+++ b/src/components/Tooltip/use-tooltip-events.tsx
@@ -357,6 +357,11 @@ const useTooltipEvents = ({
         debouncedHandleShowTooltip(resolveAnchorElementRef.current(event.target))
       })
     }
+    if (actualOpenEvents.mouseenter || actualOpenEvents.mouseover || actualOpenEvents.focus) {
+      addDelegatedListener('touchstart', (event) => {
+        debouncedHandleShowTooltip(resolveAnchorElementRef.current(event.target))
+      })
+    }
     if (actualCloseEvents.blur) {
       addDelegatedListener('focusout', (event) => {
         const targetAnchor = resolveAnchorElementRef.current(event.target)
@@ -470,6 +475,7 @@ const useTooltipEvents = ({
   useEffect(() => {
     const handleScrollResize = () => {
       handleShowRef.current(false)
+      clearTimeoutRef(tooltipShowDelayTimerRef)
     }
 
     const tooltipScrollParent = tooltipScrollParentRef.current

--- a/src/test/tooltip-anchor-selection.spec.js
+++ b/src/test/tooltip-anchor-selection.spec.js
@@ -63,6 +63,32 @@ describe('tooltip anchor selection', () => {
     await waitForTooltipToClose('scroll-resize-test')
   })
 
+  test('reopens on touch after closing from scroll', async () => {
+    render(
+      <>
+        <span data-tooltip-id="touch-scroll-test">Tap Me</span>
+        <TooltipController
+          id="touch-scroll-test"
+          content="Touch Scroll Test"
+          globalCloseEvents={{ scroll: true }}
+        />
+      </>,
+    )
+
+    const anchor = screen.getByText('Tap Me')
+
+    fireEvent.touchStart(anchor)
+    await waitForTooltip('touch-scroll-test')
+
+    fireEvent.scroll(window)
+    await waitForTooltipToStopShowing('touch-scroll-test')
+
+    fireEvent.touchStart(anchor)
+    await waitFor(() => {
+      expect(document.getElementById('touch-scroll-test')).not.toHaveClass('react-tooltip__closing')
+    })
+  })
+
   test('unmounts cleanly after opening and closing', async () => {
     const { unmount } = render(
       <>


### PR DESCRIPTION
fix #1281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltip now opens on touch interaction when touch-based opening is enabled.

* **Bug Fixes**
  * Fixed tooltip appearing after being closed by scroll or resize events.

* **Tests**
  * Added test coverage for tooltip behavior during repeated touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->