### PR TITLE
docs: add Accessibility section

### DIFF
--- a/docs/docs/accessibility.mdx
+++ b/docs/docs/accessibility.mdx
@@ -1,0 +1,157 @@
+---
+sidebar_position: 5
+---
+
+# Accessibility
+
+How to make sure your tooltips are usable by everyone, including keyboard and screen reader users.
+
+import { Tooltip } from 'react-tooltip'
+
+export const ButtonAnchor = ({ children, ...rest }) => (
+  <button
+    type="button"
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      margin: 'auto',
+      alignItems: 'center',
+      width: '60px',
+      height: '60px',
+      borderRadius: '60px',
+      color: '#222',
+      background: 'rgba(255, 255, 255, 1)',
+      cursor: 'pointer',
+      boxShadow: '3px 4px 3px rgba(0, 0, 0, 0.5)',
+      border: '1px solid #333',
+      font: 'inherit',
+      padding: 0,
+    }}
+    {...rest}
+  >
+    {children}
+  </button>
+)
+
+Tooltips are covered by several [WCAG](https://www.w3.org/TR/WCAG22/) success criteria. The most relevant ones are:
+
+- [**1.4.13 Content on Hover or Focus**](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus) — content shown on hover or focus must be **dismissible** (can be closed without moving the pointer or focus), **hoverable** (the pointer can move onto the content without it disappearing), and **persistent** (it stays visible until dismissed or no longer relevant).
+- [**2.1.1 Keyboard**](https://www.w3.org/TR/WCAG22/#keyboard) — the tooltip must be reachable and triggerable with a keyboard alone, not only with a pointer.
+- [**1.3.1 Info and Relationships**](https://www.w3.org/TR/WCAG22/#info-and-relationships) — the relationship between the anchor and its tooltip must be conveyed programmatically, so assistive technologies can announce it.
+
+The rest of this page shows how each of these maps to ReactTooltip props and markup. The [full example](#putting-it-all-together) at the end combines them.
+
+:::info
+
+ReactTooltip already opens the tooltip when the anchor receives keyboard focus (not just on hover), so most of the work is making sure your anchor is focusable and correctly associated with the tooltip.
+
+:::
+
+## Hoverable content (1.4.13)
+
+By default the tooltip disappears when the pointer leaves the anchor element — which means the pointer can't be moved onto the tooltip, and any buttons or links inside it are unreachable.
+
+Use the `clickable` prop so the pointer can move onto the tooltip content without it closing. See the [Clickable tooltip example](./getting-started#clickable-tooltip) in the Getting Started section.
+
+## Dismissible with `Esc` (1.4.13)
+
+Users must be able to close the tooltip without moving the pointer or focus. Enable the `escape` global close event so pressing the <kbd>Esc</kbd> key dismisses it.
+
+```jsx
+<Tooltip
+  id="dismissible-tooltip"
+  globalCloseEvents={{ escape: true }}
+/>
+```
+
+:::info
+
+`globalCloseEvents` accepts other options too (`scroll`, `resize`, `clickOutsideAnchor`). See the [options page](./options#available-props) for the full list.
+
+:::
+
+## Keyboard-accessible anchor (2.1.1)
+
+ReactTooltip opens the tooltip when the anchor receives focus, but only focusable elements can receive keyboard focus. Interactive elements such as `<a href="...">`, `<button>`, and form controls are focusable by default.
+
+If your anchor is a non-interactive element (like a `<span>` or `<div>`), make it focusable by adding `tabIndex={0}`.
+
+```jsx
+// ✅ natively focusable
+<button data-tooltip-id="my-tooltip">Help</button>
+
+// ✅ made focusable
+<span data-tooltip-id="my-tooltip" tabIndex={0}>Help</span>
+```
+
+:::caution
+
+Prefer a natively interactive element when the anchor is meant to be interacted with. Adding `tabIndex={0}` to a `<span>` makes it focusable but does not give it a button's role or behavior.
+
+:::
+
+## Associating the anchor and tooltip (1.3.1)
+
+So screen readers announce the tooltip content when the anchor is focused, add an `aria-describedby` attribute to the anchor referencing the tooltip's `id`.
+
+```jsx
+<button
+  data-tooltip-id="my-tooltip"
+  aria-describedby="my-tooltip"
+>
+  Help
+</button>
+<Tooltip id="my-tooltip" content="Helpful description" />
+```
+
+:::info
+
+ReactTooltip renders the tooltip element with `role="tooltip"`, so pairing it with `aria-describedby` gives assistive technologies the expected semantics.
+
+:::
+
+## Putting it all together
+
+This example combines all of the above: a keyboard-focusable anchor, associated with the tooltip via `aria-describedby`, whose content is reachable (`clickable`) and can be dismissed with <kbd>Esc</kbd> (`globalCloseEvents`).
+
+```jsx
+import { Tooltip } from 'react-tooltip'
+
+<button
+  data-tooltip-id="accessible-tooltip"
+  aria-describedby="accessible-tooltip"
+>
+  ◕‿‿◕
+</button>
+<Tooltip
+  id="accessible-tooltip"
+  clickable
+  globalCloseEvents={{ escape: true }}
+>
+  <a
+    href="https://react-tooltip.com"
+    target="_blank"
+    rel="noreferrer"
+    style={{ color: '#8ab4f8' }}
+  >
+    Read the docs
+  </a>
+</Tooltip>
+```
+
+<div style={{ display: 'flex', justifyContent: 'center', padding: '30px 0' }}>
+  <ButtonAnchor data-tooltip-id="accessible-tooltip" aria-describedby="accessible-tooltip">◕‿‿◕</ButtonAnchor>
+  <Tooltip
+    id="accessible-tooltip"
+    clickable
+    globalCloseEvents={{ escape: true }}
+  >
+    <a href="https://react-tooltip.com" target="_blank" rel="noreferrer" style={{ color: '#8ab4f8' }}>Read the docs</a>
+  </Tooltip>
+</div>
+
+:::tip
+
+Try it with the keyboard: <kbd>Tab</kbd> to the anchor to open the tooltip, <kbd>Tab</kbd> again to move into the link, and <kbd>Esc</kbd> to dismiss it.
+
+:::

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -187,11 +187,17 @@ import { Tooltip } from 'react-tooltip'
   <Tooltip anchorSelect=".my-anchor-element">Hello world!</Tooltip>
 </div>
 
-### Clickable tooltip/accessibility
+### Clickable tooltip
 
-By default the tooltip disappears when the pointer leaves the tooltip anchor element - which means you can't interact with elements inside the tooltip and that it won't meet the 'hoverable' requirement of [WCAG Success Criterion 1.4.13 Content on Hover or Focus](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus).
+By default the tooltip disappears when the pointer leaves the tooltip anchor element, which means you can't interact with elements inside the tooltip.
 
 To allow for proper usage of elements such as buttons and inputs - or to ensure the pointer can be moved over the tooltip content without it disappearing - use the `clickable` prop.
+
+:::info
+
+This is also required to meet the 'hoverable' requirement for accessible tooltips. See the [Accessibility page](./accessibility) for how to make your tooltips fully accessible.
+
+:::
 
 ```jsx
 <a id="not-clickable">◕‿‿◕</a>

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 # Troubleshooting


### PR DESCRIPTION
## Description

Adds a dedicated **Accessibility** page to the docs, as discussed in #1261.

It calls out the three WCAG success criteria most relevant to tooltips and shows how each maps to ReactTooltip:

- **1.4.13 Content on Hover or Focus** — use `clickable` so tooltip content is hoverable/reachable, and `globalCloseEvents={{ escape: true }}` so it is dismissible with <kbd>Esc</kbd>
- **2.1.1 Keyboard** — use a natively focusable anchor (or `tabIndex={0}`); ReactTooltip already opens on focus
- **1.3.1 Info and Relationships** — associate the anchor and tooltip via `aria-describedby` (ReactTooltip renders the tooltip with `role="tooltip"`)

It ends with a combined, keyboard-testable live example putting all of these together.

## Other changes

- Renames the Getting Started "Clickable tooltip/accessibility" subsection back to "Clickable tooltip" and links it to the new Accessibility page (folds in / supersedes the content from #1267, per @danielbarion's suggestion in #1261 to have a dedicated section).
- Moves Troubleshooting down one sidebar position so Accessibility sits just before it.

## Sidebar order

Getting Started → Upgrade Guide → Options → Examples → **Accessibility** → Troubleshooting

## Testing

Built the docs (`yarn build`) with no broken-link or MDX errors, and verified the new page and all live examples render and behave correctly (clickable/hoverable, Esc dismissal, native keyboard focus, `aria-describedby` association). The link inside the example tooltip meets WCAG AA/AAA contrast against the tooltip background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an accessibility guide for tooltips, including keyboard navigation, dismissal, hoverable content, and screen reader labeling.
  * Updated the clickable tooltip guidance with clearer accessibility information and a link to the new guide.
  * Reordered the Troubleshooting page in the documentation sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->